### PR TITLE
完善一些配置。

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -23,8 +23,7 @@ set-option -g default-terminal "screen-256color"  # use 256 colors
 set-option -g history-limit 100000                # scrollback buffer n lines
 set-option -g display-time 5000                   # 提示信息的持续时间；设置足够的时间以避免看不清提示，单位为毫秒
 set-option -g repeat-time 1000                    # 控制台激活后的持续时间；设置合适的时间以避免每次操作都要先激活控制台，单位为毫秒
-set-window-option -g display-panes-time 1500
-set-option -g repeat-time 0                       # Allow the arrow key to be used immediately after changing windows
+set-window-option -g display-panes-time 3000
 
 set-option -g renumber-windows on                 # window 0, 1, 2, remove 1, renumber to 0, 1
 
@@ -92,21 +91,21 @@ bind-key - split-window -v -c "#{pane_current_path}"
 # 窗口间切换
 # [prefix-hjkl] pane之间移动
 unbind-key h
-bind-key h select-pane -L
+bind-key -r h select-pane -L
 unbind-key j
-bind-key j select-pane -D
+bind-key -r j select-pane -D
 unbind-key k
-bind-key k select-pane -U
+bind-key -r k select-pane -U
 unbind-key l
-bind-key l select-pane -R
+bind-key -r l select-pane -R
 # smart pane switching with awareness of vim splits
 # [Ctrl-hjkl] pane之间移动
-bind -n C-h run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys C-h) || tmux select-pane -L"
-bind -n C-j run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys C-j) || tmux select-pane -D"
-bind -n C-k run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys C-k) || tmux select-pane -U"
-bind -n C-l run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys C-l) || tmux select-pane -R"
+bind -r -n C-h run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys C-h) || tmux select-pane -L"
+bind -r -n C-j run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys C-j) || tmux select-pane -D"
+bind -r -n C-k run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys C-k) || tmux select-pane -U"
+bind -r -n C-l run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys C-l) || tmux select-pane -R"
 # [Ctrl-l] 左右两个切  [Ctrl-\] 最近的两个切换
-bind -n C-\ run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys 'C-\\') || tmux select-pane -l"
+bind -r -n C-\ run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys 'C-\\') || tmux select-pane -l"
 bind C-l send-keys 'C-l'
 
 # [prefix-q] 展示窗口数字并选择跳转
@@ -115,10 +114,10 @@ bind-key q display-panes
 
 # 窗口大小调整
 # resize panes using PREFIX H, J, K, L
-bind H resize-pane -L 5
-bind J resize-pane -D 5
-bind K resize-pane -U 5
-bind L resize-pane -R 5
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
 
 # layout
 # [prefix-space]
@@ -134,12 +133,13 @@ setw -g mode-keys vi
 
 # [ 进入复制，space键开始选择问题  方向键移动， / 回车复制  / ] 黏贴
 bind-key [ copy-mode
-bind-key ] paste-buffer
+bind-key ] run " tmux set-buffer \"$(xclip -o -sel clipboard)\"; tmux paste-buffer"
 
 # Copy and paste like in vim
 # p 换成paste
 unbind p
-bind p paste-buffer
+bind p run " tmux set-buffer \"$(xclip -o -sel clipboard)\"; tmux paste-buffer"
+bind -n C-v run " tmux set-buffer \"$(xclip -o -sel clipboard)\"; tmux paste-buffer"
 
 
 # the following vi-copy bindings match my vim settings
@@ -148,16 +148,16 @@ bind p paste-buffer
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
 
-bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel " tmux save-buffer - | xclip -i -sel clipboard"
 bind-key -T copy-mode-vi Escape send-keys -X cancel
 bind-key -T copy-mode-vi H send-keys -X start-of-line
 bind-key -T copy-mode-vi L send-keys -X end-of-line
 
 # Update default binding of `Enter` to also use copy-pipe
 unbind-key -T copy-mode-vi Enter
-bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel " tmux save-buffer - | xclip -i -sel clipboard"
 # bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
-bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel " tmux save-buffer - | xclip -i -sel clipboard"
 
 # for osx
 # Enable native Mac OS X copy/paste  对于mac用户，可以复制到系统剪贴板

--- a/tmux.conf
+++ b/tmux.conf
@@ -57,13 +57,14 @@ set-window-option -g other-pane-height 25
 set-window-option -g other-pane-width 80
 
 # [prefix-c] 创建新窗口
-bind-key c new-window
+bind-key c new-window -c "#{pane_current_path}"
 # [prefix-数字] 切换窗口
 # [prefix-p] 切换窗口
 
 # [prefix-t/T] 切换窗口
 bind-key t next-window
 bind-key T previous-window
+bind-key N previous-window
 # bind-key space next-window
 # bind-key bspace previous-window
 
@@ -85,8 +86,8 @@ unbind %
 
 # key bindings for horizontal and vertical panes
 # 键 [\|] 和 [_-] 少敲一个shift键
-bind-key \ split-window -h
-bind-key - split-window -v
+bind-key \ split-window -h -c "#{pane_current_path}"
+bind-key - split-window -v -c "#{pane_current_path}"
 
 # 窗口间切换
 # [prefix-hjkl] pane之间移动
@@ -100,12 +101,12 @@ unbind-key l
 bind-key l select-pane -R
 # smart pane switching with awareness of vim splits
 # [Ctrl-hjkl] pane之间移动
-bind -n C-h run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys C-h) || tmux select-pane -L"
-bind -n C-j run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys C-j) || tmux select-pane -D"
-bind -n C-k run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys C-k) || tmux select-pane -U"
-bind -n C-l run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys C-l) || tmux select-pane -R"
+bind -n C-h run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys C-h) || tmux select-pane -L"
+bind -n C-j run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys C-j) || tmux select-pane -D"
+bind -n C-k run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys C-k) || tmux select-pane -U"
+bind -n C-l run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys C-l) || tmux select-pane -R"
 # [Ctrl-l] 左右两个切  [Ctrl-\] 最近的两个切换
-bind -n C-\ run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys 'C-\\') || tmux select-pane -l"
+bind -n C-\ run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)(vim|vi)$' && tmux send-keys 'C-\\') || tmux select-pane -l"
 bind C-l send-keys 'C-l'
 
 # [prefix-q] 展示窗口数字并选择跳转

--- a/tmux.conf
+++ b/tmux.conf
@@ -167,10 +167,13 @@ set-option -g default-command "/bin/bash -c 'which reattach-to-user-namespace >/
 # -------------------------------- mouse begin --------------------------------
 # mouse behavior
 # Using set -gq instead of set -g will silence the unknown option error, while still setting it on old versions of tmux
-setw -gq mode-mouse on
-set -gq mouse-select-pane on
-set -gq mouse-resize-pane on
-set -gq mouse-select-window on
+#setw -gq mode-mouse on
+#set -gq mouse-select-pane on
+#set -gq mouse-resize-pane on
+#set -gq mouse-select-window on
+
+# luice: after tmux 2.1, the mouse mode changed into:
+set-option -g mouse on
 # -------------------------------- mouse end --------------------------------
 
 # -------------------------------- status line begin  --------------------------------


### PR DESCRIPTION
0. 系统：Ubuntu 16.04 LTS，tmux 版本：2.8

1. 完善 vim 切窗与 tmux 切窗无缝对接，如果 vim 是以 vi 命令启动的，同样可以自由切换窗格。

2. 新窗口 / 窗格打开时，直接切换到当前路径。

3. 修改鼠标支持的配置，以适配 tmux 2.1 以上版本。

4. 利用 xclip 实现与系统剪贴板的无缝对接，增加 Ctrl-v 直接粘贴功能（无需 PREFIX）

5. 切换窗格、更改窗格大小命令，支持重复。

6. 增加 [ PREFIX - N ] 键，与 [ PREFIX - n ] 对应，分别为向前 / 向后切换窗口。[ PREFIX - T ] 这个键位不太友好，与 PREFIX 都在左手不太方便。